### PR TITLE
Max pod lifetime

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -91,6 +91,8 @@ Command options for *serve*-command:
 | ``--pycharm-port``         | The port of the pycharm debug server. This is only used in combination        |
 |                            | with the '--pycharm-host' option                                              |
 +----------------------------+-------------------------------------------------------------------------------+
+| ``--max-lifetime``         | If specified,  maximum requests after which pod is restarted                  |
++----------------------------+-------------------------------------------------------------------------------+
 
 **Please note**: :code:`req-queue-len` parameter is set to a default value of 10. It means, that if the length of the
 asynchronous tasks' queue will exceed 10, readiness probe will return the status 400 until the length of the queue
@@ -366,6 +368,8 @@ Command options for *consume*-command:
 +---------------------------+-------------------------------------------------------------------------------------+
 | ``--webhook-url``         | If specified, webhooks will be sent to this url                                     |
 +---------------------------+-------------------------------------------------------------------------------------+
+| ``--max-lifetime``         | If specified,  maximum requests after which pod is restarted                  |
++----------------------------+-------------------------------------------------------------------------------+
 
 **Please note**: :code:`req-queue-len` parameter is set to a default value of 10. It means, that if the length of
 asynchronous tasks queue will exceed 10, readiness probe will return status 400 until the length of tasks gets below the

--- a/hurricane/management/commands/consume.py
+++ b/hurricane/management/commands/consume.py
@@ -42,6 +42,7 @@ class Command(BaseCommand):
         - ``--autoreload`` - reload code on change
         - ``--debug`` - set Tornado's Debug flag
         - ``--reconnect`` - try to reconnect this client automatically as the broker is available again
+        - ``--max-lifetime``- If specified,  maximum requests after which pod is restarted
     """
 
     help = "Start a Tornado-powered Django AMQP 0-9-1 consumer"
@@ -108,6 +109,9 @@ class Command(BaseCommand):
             "--webhook-url",
             type=str,
             help="Url for webhooks",
+        )
+        parser.add_argument(
+            "--max-lifetime", type=int, default=None, help="Maximum requests after which pod is restarted"
         )
 
     def handle(self, *args, **options):

--- a/hurricane/management/commands/serve.py
+++ b/hurricane/management/commands/serve.py
@@ -47,6 +47,7 @@ class Command(BaseCommand):
         - ``--command`` - repetitive command for adding execution of management commands before serving
         - ``--check-migrations`` - check if all migrations were applied before starting application
         - ``--webhook-url``- If specified, webhooks will be sent to this url
+        - ``--max-lifetime``- If specified,  maximum requests after which pod is restarted
     """
 
     help = "Start a Tornado-powered Django web server"
@@ -97,6 +98,10 @@ class Command(BaseCommand):
             type=str,
             help="Url for webhooks",
         )
+        parser.add_argument(
+            "--max-lifetime", type=int, default=None, help="Maximum requests after which pod is restarted"
+        )
+
         parser.add_argument("--pycharm-host", type=str, default=None, help="The host of the pycharm debug server")
         parser.add_argument("--pycharm-port", type=int, default=None, help="The port of the pycharm debug server")
 

--- a/hurricane/server/__init__.py
+++ b/hurricane/server/__init__.py
@@ -51,7 +51,11 @@ def make_probe_server(options, check_func):
         (
             options["liveness_probe"],
             DjangoLivenessHandler,
-            {"check_handler": check_func, "webhook_url": options["webhook_url"]},
+            {
+                "check_handler": check_func,
+                "webhook_url": options["webhook_url"],
+                "max_lifetime": options["max_lifetime"],
+            },
         ),
         (
             options["readiness_probe"],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -427,6 +427,17 @@ class HurricanStartServerTests(HurricanServerTest):
         with self.assertRaises(SystemExit):
             signal_handler("signal", "frame")
 
+    @HurricanServerTest.cycle_server(args=["--max-lifetime", "2"])
+    def test_max_lifetime(self):
+        self.app_client.get("/")
+        self.app_client.get("/")
+        res = self.probe_client.get(self.alive_route)
+        self.assertEqual(res.status, 200)
+        self.app_client.get("/")
+        res = self.probe_client.get(self.alive_route)
+        out, err = self.driver.get_output(read_all=True)
+        self.assertEqual(res.status, 400)
+
     @HurricanServerTest.cycle_server(env={"DJANGO_SETTINGS_MODULE": "tests.testapp.settings_media"}, args=["--media"])
     def test_django_media(self):
         response = requests.get("http://localhost:8000/media/logo.png")


### PR DESCRIPTION
Closes #83 

- --max-lifetime option, which defines number of requests before /alive probe starts to response with a status 400. This is when pod is restarted
- test for the option
