### PR TITLE
Incompatibility logic for autoreload and debug

### DIFF
--- a/hurricane/management/commands/serve.py
+++ b/hurricane/management/commands/serve.py
@@ -17,9 +17,7 @@ from hurricane.server import (
     make_probe_server,
     sanitize_probes,
 )
-from hurricane.server.debugging import setup_debugpy, setup_pycharm
-from hurricane.webhooks import StartupWebhook
-from hurricane.webhooks.base import WebhookStatus
+from hurricane.server.debugging import setup_debugging
 
 
 class Command(BaseCommand):
@@ -150,8 +148,7 @@ class Command(BaseCommand):
         else:
             logger.info("No probe application running")
 
-        setup_debugpy(options)
-        setup_pycharm(options)
+        setup_debugging(options)
 
         loop = asyncio.get_event_loop()
 

--- a/hurricane/server/debugging.py
+++ b/hurricane/server/debugging.py
@@ -1,4 +1,12 @@
 from hurricane.server import logger
+from hurricane.server.exceptions import IncompatibleOptions
+
+
+def setup_debugging(options):
+    if options["autoreload"] and (options["pycharm_host"] or options["debugger"]):
+        raise IncompatibleOptions("Autoreload and debugger are not compatible")
+    setup_debugpy(options)
+    setup_pycharm(options)
 
 
 def setup_debugpy(options):

--- a/hurricane/server/exceptions.py
+++ b/hurricane/server/exceptions.py
@@ -1,0 +1,7 @@
+class IncompatibleOptions(Exception):
+
+    """
+    Exception class for simultaneous use of incompatible options.
+    """
+
+    pass

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -2,7 +2,8 @@ import sys
 
 import mock
 
-from hurricane.server.debugging import setup_debugpy, setup_pycharm
+from hurricane.server.debugging import setup_debugging, setup_debugpy, setup_pycharm
+from hurricane.server.exceptions import IncompatibleOptions
 from hurricane.testing import HurricanServerTest
 
 
@@ -16,6 +17,10 @@ class HurricanDebuggerServerTest(HurricanServerTest):
         out, err = self.driver.get_output(read_all=True)
         self.assertEqual(res.status, 200)
         self.assertIn("Listening for debug clients at port 5678", out)
+
+    def test_incompatible_debugger_and_autoreload(self):
+        with self.assertRaises(IncompatibleOptions):
+            setup_debugging({"autoreload": True, "debugger": True, "pycharm_host": True})
 
     def test_debugger_success_and_import_error(self):
         options = {"debugger": True, "debugger_port": 8071}


### PR DESCRIPTION
Fixes #85

As discussed with @Schille `autoreload` option in combination with a `debugger` is an edge case, that is not easy to solve right now. 

That is why our solution is to add an error for the incompatible options, which will notify the user, that he should change the command / remove one option.